### PR TITLE
Allow array values with individual foreign key checks

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -70,7 +70,7 @@ module Csvlint
           # so that later we can check whether those foreign keys reference these values
           @foreign_key_references.each do |foreign_key|
             referenced_columns = foreign_key["referenced_columns"]
-            key = referenced_columns.map{ |column| column.validate(values[column.number - 1], row) }
+            key = referenced_columns.map{ |column| values[column.number - 1] }
             known_values = @foreign_key_reference_values[foreign_key] ||= {}
             (known_values[key] ||= []) << row
           end
@@ -79,7 +79,7 @@ module Csvlint
           # we might not have parsed those other tables
           @foreign_keys.each do |foreign_key|
             referencing_columns = foreign_key["referencing_columns"]
-            key = referencing_columns.map{ |column| column.validate(values[column.number - 1], row) }
+            key = referencing_columns.map{ |column| values[column.number - 1] }
             known_values = @foreign_key_values[foreign_key] ||= {}
             (known_values[key] ||= []) << row
           end

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -104,6 +104,9 @@ module Csvlint
     end
 
     def validate_stream
+      if (@source.nil?)
+        return
+      end
       @current_line = 1
       @source.each_line do |line|
         break if line_limit_reached?


### PR DESCRIPTION
There is an unenforced restriction that any array-valued columns can not be part of a multi-column foreign key.

Not sure that would even make sense.
