### PR TITLE
Return [] not nil for empty array values

### DIFF
--- a/lib/csvlint/csvw/column.rb
+++ b/lib/csvlint/csvw/column.rb
@@ -95,7 +95,7 @@ module Csvlint
         string_value = string_value || @default
         if null.include? string_value
           validate_required(nil, row)
-          values = nil
+          values = @separator.nil? ? nil : []
           return values
         else
           string_values = @separator.nil? ? [string_value] : string_value.split(@separator)


### PR DESCRIPTION
A blank cell in an array column would cause an error along the lines of `nil.each` is not a function.

An empty array should be `[]`, which makes it behave as you'd expect. In particular, an empty array will fail a `required: true` check.