### PR TITLE
Don't iterate array values if nil

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -88,8 +88,10 @@ module Csvlint
               #     [ [ "5", "7", "9" ] ]
               # We want it like this:
               #     [ ["5"], ["7"], ["9"] ]
-              key[0].each do |subkey|
-                (known_values[ [subkey] ] ||= []) << row
+              if key[0] != nil
+                key[0].each do |subkey|
+                  (known_values[ [subkey] ] ||= []) << row
+                end
               end
             else
               (known_values[key] ||= []) << row


### PR DESCRIPTION
I'm not quite sure what's causing this, but when we delete rows with
array values in them, we get errors on the empty rows, because we're
trying to iterate a list which is actually nil. I suspect this is a
side-effect of interpreting empty array values as [], not nil.

