### PR TITLE
Fix for primary keys with non-string datatypes

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -61,7 +61,7 @@ module Csvlint
         end unless columns.empty?
         if validate
           unless @primary_key.nil?
-            key = @primary_key.map { |column| column.validate(values[column.number - 1], row) }
+            key = @primary_key.map { |column| values[column.number - 1] }
             colnum = if primary_key.length == 1 then primary_key[0].number else nil end
             build_errors(:duplicate_key, :schema, row, colnum, key, @primary_key_values[key]) if @primary_key_values.include?(key)
             @primary_key_values[key] = row


### PR DESCRIPTION
If there is a primaryKey defined, and that column has a non-string
datatype, you get a crash like:

```
in `parse': undefined method `gsub!' for 1.0:Float (NoMethodError)
```

The crash is caused by trying to parse a string as a number, but the
input value is already a numeric type.

This in turn is caused by calling column.validate twice on the same csv
cell. The first time through, the cells are validated and inflated, and
stored in the values array. Then when the primary keys are checked, we
try to re-validate the already inflated values.

The fix is to just use them as-is, dont re-validate.
