### PR TITLE
Fix filename urls

### DIFF
--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -12,6 +12,7 @@ require 'uri_template'
 
 require 'csvlint/error_message'
 require 'csvlint/error_collector'
+require 'csvlint/file_url'
 require 'csvlint/validate'
 require 'csvlint/field'
 

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -80,8 +80,7 @@ module Csvlint
         end
         schema.tables.keys.each do |source|
           begin
-            source = source.sub("file:","")
-            source = File.new( source )
+            source = File.new( FileUrl.path(source) )
           rescue Errno::ENOENT
             return_error "#{source} not found"
           end unless source =~ /^http(s)?/

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -80,7 +80,7 @@ module Csvlint
         end
         schema.tables.keys.each do |source|
           begin
-            source = File.new( FileUrl.path(source) )
+            source = FileUrl.file(source)
           rescue Errno::ENOENT
             return_error "#{source} not found"
           end unless source =~ /^http(s)?/

--- a/lib/csvlint/csvw/property_checker.rb
+++ b/lib/csvlint/csvw/property_checker.rb
@@ -454,7 +454,7 @@ module Csvlint
             if value.instance_of? String
               schema_url = URI.join(base_url, value).to_s
               schema_base_url = schema_url
-              schema_ref = schema_url.start_with?("file:") ? File.new(schema_url[5..-1]) : schema_url
+              schema_ref = schema_url.start_with?("file:") ? File.new(FileUrl.path(schema_url)) : schema_url
               schema = JSON.parse( open(schema_ref).read )
               schema["@id"] = schema["@id"] ? URI.join(schema_url, schema["@id"]).to_s : schema_url
               if schema["@context"]

--- a/lib/csvlint/csvw/property_checker.rb
+++ b/lib/csvlint/csvw/property_checker.rb
@@ -454,7 +454,7 @@ module Csvlint
             if value.instance_of? String
               schema_url = URI.join(base_url, value).to_s
               schema_base_url = schema_url
-              schema_ref = schema_url.start_with?("file:") ? File.new(FileUrl.path(schema_url)) : schema_url
+              schema_ref = FileUrl.file(schema_url)
               schema = JSON.parse( open(schema_ref).read )
               schema["@id"] = schema["@id"] ? URI.join(schema_url, schema["@id"]).to_s : schema_url
               if schema["@context"]

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -22,7 +22,7 @@ module Csvlint
 
       def validate_header(header, table_url, strict)
         reset
-        table_url = Csvlint::FileUrl::url(table_url) if table_url.instance_of? File
+        table_url = FileUrl::url(table_url) if table_url.instance_of? File
         @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_header(header, strict)
@@ -33,7 +33,7 @@ module Csvlint
 
       def validate_row(values, row=nil, all_errors=[], table_url, validate)
         reset
-        table_url = Csvlint::FileUrl::url(table_url) if table_url.instance_of? File
+        table_url = FileUrl::url(table_url) if table_url.instance_of? File
         @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_row(values, row, validate)

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -22,7 +22,7 @@ module Csvlint
 
       def validate_header(header, table_url, strict)
         reset
-        table_url = "file:#{File.absolute_path(table_url)}" if table_url.instance_of? File
+        table_url = Csvlint::FileUrl::url(table_url) if table_url.instance_of? File
         @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_header(header, strict)
@@ -33,7 +33,7 @@ module Csvlint
 
       def validate_row(values, row=nil, all_errors=[], table_url, validate)
         reset
-        table_url = "file:#{File.absolute_path(table_url)}" if table_url.instance_of? File
+        table_url = Csvlint::FileUrl::url(table_url) if table_url.instance_of? File
         @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_row(values, row, validate)

--- a/lib/csvlint/file_url.rb
+++ b/lib/csvlint/file_url.rb
@@ -7,9 +7,13 @@ module Csvlint
       #URI.encode(File.expand_path(path).gsub(/^\/*/, "file:///"))
     end
 
-    # Convert an file:// uri to a plain path
-    def FileUrl.path(uri)
-      uri.gsub(/^file:\/\//, "")
+    # Convert an file:// uri to a File
+    def FileUrl.file(uri)
+      if uri.start_with?("file:")
+        File.new(uri.gsub(/^file:\/\//, ""))
+      else
+        uri
+      end
     end
   end
 end

--- a/lib/csvlint/file_url.rb
+++ b/lib/csvlint/file_url.rb
@@ -1,0 +1,15 @@
+module Csvlint
+  module FileUrl
+
+    # Convert a path to an absolute file:// uri
+    def FileUrl.url(path)
+      File.expand_path(path).gsub(/^\/*/, "file:///")
+      #URI.encode(File.expand_path(path).gsub(/^\/*/, "file:///"))
+    end
+
+    # Convert an file:// uri to a plain path
+    def FileUrl.path(uri)
+      uri.gsub(/^file:\/\//, "")
+    end
+  end
+end

--- a/lib/csvlint/file_url.rb
+++ b/lib/csvlint/file_url.rb
@@ -3,14 +3,15 @@ module Csvlint
 
     # Convert a path to an absolute file:// uri
     def FileUrl.url(path)
-      File.expand_path(path).gsub(/^\/*/, "file:///")
-      #URI.encode(File.expand_path(path).gsub(/^\/*/, "file:///"))
+      URI.encode(File.expand_path(path).gsub(/^\/*/, "file:///"))
     end
 
     # Convert an file:// uri to a File
     def FileUrl.file(uri)
       if uri.start_with?("file:")
-        File.new(uri.gsub(/^file:\/\//, ""))
+        uri = URI.decode(uri)
+        uri = uri.gsub(/^file:\/*/, "/")
+        File.new(uri)
       else
         uri
       end

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -465,7 +465,7 @@ module Csvlint
           template = URITemplate.new(template)
           path = template.expand('url' => @source_url)
           url = URI.join(@source_url, path)
-          url = File.new(FileUrl.path(url)) if url.to_s =~ /^file:/
+          url = FileUrl.file(url)
           schema = Schema.load_from_uri(url)
           if schema.instance_of? Csvlint::Csvw::TableGroup
             if schema.tables[@source_url]

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -433,13 +433,14 @@ module Csvlint
 
     def locate_schema
 
+
       @source_url = nil
       warn_if_unsuccessful = false
       case @source
         when StringIO
           return
         when File
-          @source_url = "file:#{URI.encode(File.expand_path(@source))}"
+          @source_url = FileUrl.url(@source)
         else
           @source_url = @source
       end
@@ -464,7 +465,7 @@ module Csvlint
           template = URITemplate.new(template)
           path = template.expand('url' => @source_url)
           url = URI.join(@source_url, path)
-          url = File.new(url.to_s.sub(/^file:/, "")) if url.to_s =~ /^file:/
+          url = File.new(FileUrl.path(url)) if url.to_s =~ /^file:/
           schema = Schema.load_from_uri(url)
           if schema.instance_of? Csvlint::Csvw::TableGroup
             if schema.tables[@source_url]


### PR DESCRIPTION
When loading a schema that has filenames as the table urls, they get converted from a relative path to an absolute path, and then converted to a file:// url. eg. "foo.csv" might become "file:///tmp/schema/foo.csv".

Those urls get used as hash keys for the different schema tables.

Throughout the codebase there's snippets of code here and there that convert back and forth between file urls and plain file paths.

Sometimes they get it wrong.  eg. `csvlint --schema=schema.json file.csv` won't see the file, but will quietly declare that it's valid.

In order to get that to work you need `csvlint --schema=schema.json //$PWD/file.csv`. The code that converts the filename to an url is broken, and needs the extra `//` to get it to work.


This PR adds a FileUrl module with a pair of functions to convert back and forth between the two. The codebase has been changed to use those functions.

This fixes the broken bits, while maintaining the rest of the expected behaviour.