### PR TITLE
Pass flag to allow malformed schema errors to be dumped

### DIFF
--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -58,7 +58,7 @@ module Csvlint
 
       def get_schema(schema)
         begin
-          schema = Csvlint::Schema.load_from_uri(schema, false)
+          schema = Csvlint::Schema.load_from_uri(schema, options[:dump_errors])
         rescue Csvlint::Csvw::MetadataError => e
           return_error "invalid metadata: #{e.message}#{" at " + e.path if e.path}"
         rescue OpenURI::HTTPError, Errno::ENOENT


### PR DESCRIPTION
If the schema is malformed, the schema load throws the error `invalid metadata: malformed JSON`, with no help as to where the schema is malformed.

This passes the `:dump_errors` cli option into the schema loader methods, which then throws sufficient detail to help chase down whats dumped with your schema.