### PR TITLE
Add optional dateCheckPattern with datePattern

### DIFF
--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -164,30 +164,35 @@ module Csvlint
           'http://www.w3.org/2001/XMLSchema#dateTime' => lambda do |value, constraints|
             date_pattern = constraints["datePattern"] || "%Y-%m-%dT%H:%M:%SZ"
             d = DateTime.strptime(value, date_pattern)
+            date_pattern = constraints["dateCheckPattern"] || date_pattern
             raise ArgumentError unless d.strftime(date_pattern) == value
             d
           end,
           'http://www.w3.org/2001/XMLSchema#date' => lambda do |value, constraints|
             date_pattern = constraints["datePattern"] || "%Y-%m-%d"
             d = Date.strptime(value, date_pattern)
+            date_pattern = constraints["dateCheckPattern"] || date_pattern
             raise ArgumentError unless d.strftime(date_pattern) == value
             d
           end,
           'http://www.w3.org/2001/XMLSchema#time' => lambda do |value, constraints|
             date_pattern = constraints["datePattern"] || "%H:%M:%S"
             d = DateTime.strptime(value, date_pattern)
+            date_pattern = constraints["dateCheckPattern"] || date_pattern
             raise ArgumentError unless d.strftime(date_pattern) == value
             d
           end,
           'http://www.w3.org/2001/XMLSchema#gYear' => lambda do |value, constraints|
             date_pattern = constraints["datePattern"] || "%Y"
             d = Date.strptime(value, date_pattern)
+            date_pattern = constraints["dateCheckPattern"] || date_pattern
             raise ArgumentError unless d.strftime(date_pattern) == value
             d
           end,
           'http://www.w3.org/2001/XMLSchema#gYearMonth' => lambda do |value, constraints|
             date_pattern = constraints["datePattern"] || "%Y-%m"
             d = Date.strptime(value, date_pattern)
+            date_pattern = constraints["dateCheckPattern"] || date_pattern
             raise ArgumentError unless d.strftime(date_pattern) == value
             d
           end,


### PR DESCRIPTION
In field.rb the datePattern field gets used as a strptime format to parse the date/time. Then it gets used again as a strftime format to format the DateTime object back out to a string, and a validation error is thrown if these don't match.

The trouble is, strptime and strftime are not symmetrical.

eg. `%H:%M` will parse `6:02` and `06:02`, but will always format it back out to `06:02`

We can use `%-H:%M` in this case if we want it to format back to `6:02`, but that's not a valid strptime format.

This patch adds an optional dateCheckPattern that is used with strftime. If it doesn't exist, we fall back to datePattern as before.