### PR TITLE
Allow 24:00 end of day flag as a valid time

### DIFF
--- a/lib/csvlint/csvw/date_format.rb
+++ b/lib/csvlint/csvw/date_format.rb
@@ -179,7 +179,7 @@ module Csvlint
           "HH:mm:ss" => Regexp.new("^#{FIELDS["HH"]}:#{FIELDS["mm"]}:(?<second>#{FIELDS["ss"]})$"),
           "HHmmss" => Regexp.new("^#{FIELDS["HH"]}#{FIELDS["mm"]}(?<second>#{FIELDS["ss"]})$"),
           "HH:mm" => Regexp.new("^#{FIELDS["HH"]}:#{FIELDS["mm"]}$"),
-          "H:mm" => Regexp.new("^#{FIELDS["H"]}:#{FIELDS["mm"]}$"),
+          "H:mm" => Regexp.new("^#{FIELDS["H"]}:#{FIELDS["mm"]}|(?<hour>24):(?<minute>00)$"),
           "HHmm" => Regexp.new("^#{FIELDS["HH"]}#{FIELDS["mm"]}$")
         }
 


### PR DESCRIPTION
XMLSchema allows 24:00 as the end of day marker for times, for use by PMHC.

This tweak our custom H:mm format (added for PMHC) to allow for the end of day flag that strptime otherwise doesn't permit.
