### PR TITLE
fix FileUrl decode/encode for Ruby 2.7+

### DIFF
--- a/lib/csvlint/file_url.rb
+++ b/lib/csvlint/file_url.rb
@@ -1,14 +1,16 @@
+require "addressable"
+
 module Csvlint
   module FileUrl
     # Convert a path to an absolute file:// uri
     def self.url(path)
-      URI.encode_www_form_component(File.expand_path(path).gsub(/^\/*/, "file:///"))
+      Addressable::URI.convert_path(File.expand_path(path)).to_s
     end
 
     # Convert an file:// uri to a File
     def self.file(uri)
       if /^file:/.match?(uri.to_s)
-        uri = URI.decode_www_form_component(uri)
+        uri = Addressable::URI.unencode(uri)
         uri = uri.gsub(/^file:\/*/, "/")
         File.new(uri)
       else


### PR DESCRIPTION
Ruby 2.7 removed URI.encode and URI.decode as they are not "correct" according to rfc3986.  They added methods URI.encode_www_form_component but they are NOT backwards compatible with the older methods, such as encoding a space to `%20` vs `+`.

The last commit to use encode_www_form_component made things worse; as that percent encodes `://`, causing regexs on `file://` to fail.

Change to using Addressable, which is already a dependency for csvlint and has similar escape/unescape methods to what we used previously, plus some extra sugar for path => file url conversion.