### PR TITLE
FileUrl: parse uri before unencoding

### DIFF
--- a/lib/csvlint/file_url.rb
+++ b/lib/csvlint/file_url.rb
@@ -10,7 +10,7 @@ module Csvlint
     # Convert an file:// uri to a File
     def self.file(uri)
       if /^file:/.match?(uri.to_s)
-        uri = Addressable::URI.unencode(uri)
+        uri = Addressable::URI.unencode(Addressable::URI.parse(uri))
         uri = uri.gsub(/^file:\/*/, "/")
         File.new(uri)
       else


### PR DESCRIPTION
unencode() calls `uri.to_str` internally, which requires the uri be an instance of Addressable (which defines the `to_str` method), so parse the uri first.
