### PR TITLE
Handle no fk reference values

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -124,7 +124,7 @@ module Csvlint
 
       def validate_foreign_key_references(foreign_key, remote_url, remote)
         reset
-        local = @foreign_key_reference_values[foreign_key]
+        local = @foreign_key_reference_values[foreign_key] || {}
         context = {"from" => {"url" => remote_url.to_s.split("/")[-1], "columns" => foreign_key["columnReference"]}, "to" => {"url" => @url.to_s.split("/")[-1], "columns" => foreign_key["reference"]["columnReference"]}}
         colnum = foreign_key["referencing_columns"].length == 1 ? foreign_key["referencing_columns"][0].number : nil
         remote.each_key do |r|

--- a/lib/csvlint/version.rb
+++ b/lib/csvlint/version.rb
@@ -1,3 +1,3 @@
 module Csvlint
-  VERSION = "1.0.0.1"
+  VERSION = "1.0.0.2"
 end


### PR DESCRIPTION
Handles an edge case where the referenced table for foreign keys has no data.

Plus version bump to 1.0.0.2 so our apps pick up the changes.