### PR TITLE
require activesupport; fix for activesupport 7.1.0

### DIFF
--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -5,6 +5,7 @@ require "set"
 require "tempfile"
 require "typhoeus"
 
+require "active_support"
 require "active_support/core_ext/date/conversions"
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/object"


### PR DESCRIPTION
The release of ActiveSupport 7.1.0 broke the cherry-picking of activesupport components. For the gory details, see https://github.com/rails/rails/issues/49495

The fix follows ActiveSupport's recommendations to
  require "activesupport"
before cherry-picking components.