### PR TITLE
Only confirm encoding type if we have a non-null encoding.

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -341,7 +341,7 @@ module Csvlint
           build_warnings(:encoding, :context)
         end
       end
-      build_warnings(:encoding, :context) if @encoding != "UTF-8"
+      build_warnings(:encoding, :context) if !@encoding.nil? and @encoding != "UTF-8"
     end
 
     def check_mixed_linebreaks


### PR DESCRIPTION
This PR fixes #26 

Changes proposed in this pull request:

- Only check for UTF-8 encoding when we have encoding read from a validated source.
